### PR TITLE
Fixed multiple expressions with nullish coalescing not covered in brackets breaking calculation results

### DIFF
--- a/src/elements/helpers/TransformElement.ts
+++ b/src/elements/helpers/TransformElement.ts
@@ -123,7 +123,7 @@ export abstract class TransformElement extends BaseElement {
       let localOp = this.finalTransform.localOpacity
 
       for (i = 0; i < length; i++) {
-        localOp *= this.localTransforms[i]?.opacity ?? 1 * 0.01
+        localOp *= (this.localTransforms[i]?.opacity ?? 1) * 0.01
       }
       this.finalTransform.localOpacity = localOp
     }

--- a/src/elements/html/HCameraElement.ts
+++ b/src/elements/html/HCameraElement.ts
@@ -236,9 +236,9 @@ export class HCameraElement extends FrameElement {
 
         if (this.p) {
           diffVector = [
-            this.p.v[0] ?? 0 - this.a.v[0],
-            this.p.v[1] ?? 0 - this.a.v[1],
-            this.p.v[2] ?? 0 - this.a.v[2],
+            (this.p.v[0] ?? 0) - this.a.v[0],
+            (this.p.v[1] ?? 0) - this.a.v[1],
+            (this.p.v[2] ?? 0) - this.a.v[2],
           ]
         } else if (this.px && this.py && this.pz) {
           diffVector = [

--- a/src/utils/expressions/ExpressionManager.ts
+++ b/src/utils/expressions/ExpressionManager.ts
@@ -868,7 +868,7 @@ function linear(
       arr = createTypedArray(ArrayType.Float32, len)
 
     for (let i = 0; i < len; i += 1) {
-      arr[i] = value1[i] ?? 0 + (value2[i] ?? 0 - (value1[i] ?? 0)) * perc
+      arr[i] = (value1[i] ?? 0) + ((value2[i] ?? 0) - (value1[i] ?? 0)) * perc
     }
 
     return arr
@@ -905,7 +905,7 @@ function random(minFromProps?: number | number[], maxFormProps?: number | number
       rnd = Math.random()
 
     for (let i = 0; i < len; i += 1) {
-      arr[i] = (min as number[])[i] ?? 0 + rnd * (max[i] ?? 0 - ((min as number[])[i] ?? 0))
+      arr[i] = ((min as number[])[i] ?? 0) + rnd * ((max[i] ?? 0) - ((min as number[])[i] ?? 0))
     }
 
     return arr
@@ -1130,7 +1130,7 @@ function sum(aFromProps: unknown, bFromProps: unknown) {
 
     while (i < lenA || i < lenB) {
       if ((typeof a[i] === 'number' || (a as unknown[])[i] instanceof Number) && (typeof b[i] === 'number' || (b as unknown[])[i] instanceof Number)) {
-        retArr[i] = a[i] ?? 0 + (b[i] ?? 0)
+        retArr[i] = (a[i] ?? 0) + (b[i] ?? 0)
         i++
         continue
       }

--- a/src/utils/properties/KeyframedMultidimensionalProperty.ts
+++ b/src/utils/properties/KeyframedMultidimensionalProperty.ts
@@ -36,15 +36,15 @@ export class KeyframedMultidimensionalProperty<
           s.length === 2 &&
           !(s[0] === e[0] && s[1] === e[1]) &&
           pointOnLine2D(
-            s[0] ?? 0, s[1] ?? 0, e[0] ?? 0, e[1] ?? 0, s[0] ?? 0 + (to[0] ?? 0), s[1] ?? 0 + (to[1] ?? 0)
+            s[0] ?? 0, s[1] ?? 0, e[0] ?? 0, e[1] ?? 0, (s[0] ?? 0) + (to[0] ?? 0), (s[1] ?? 0) + (to[1] ?? 0)
           ) &&
           pointOnLine2D(
             s[0] ?? 0,
             s[1] ?? 0,
             e[0] ?? 0,
             e[1] ?? 0,
-            e[0] ?? 0 + (ti[0] ?? 0),
-            e[1] ?? 0 + (ti[1] ?? 0)
+            (e[0] ?? 0) + (ti[0] ?? 0),
+            (e[1] ?? 0) + (ti[1] ?? 0)
           ) ||
           s.length === 3 &&
           !(s[0] === e[0] && s[1] === e[1] && s[2] === e[2]) &&
@@ -55,9 +55,9 @@ export class KeyframedMultidimensionalProperty<
             e[0] ?? 0,
             e[1] ?? 0,
             e[2] ?? 0,
-            s[0] ?? 0 + (to[0] ?? 0),
-            s[1] ?? 0 + (to[1] ?? 0),
-            s[2] ?? 0 + (to[2] ?? 0)
+            (s[0] ?? 0) + (to[0] ?? 0),
+            (s[1] ?? 0) + (to[1] ?? 0),
+            (s[2] ?? 0) + (to[2] ?? 0)
           ) &&
           pointOnLine3D(
             s[0] ?? 0,
@@ -66,9 +66,9 @@ export class KeyframedMultidimensionalProperty<
             e[0] ?? 0,
             e[1] ?? 0,
             e[2] ?? 0,
-            e[0] ?? 0 + (ti[0] ?? 0),
-            e[1] ?? 0 + (ti[1] ?? 0),
-            e[2] ?? 0 + (ti[2] ?? 0)
+            (e[0] ?? 0) + (ti[0] ?? 0),
+            (e[1] ?? 0) + (ti[1] ?? 0),
+            (e[2] ?? 0) + (ti[2] ?? 0)
           )
         ) {
           ; (data.k[i] as Keyframe).to = null

--- a/src/utils/shapes/modifiers/OffsetPathModifier.ts
+++ b/src/utils/shapes/modifiers/OffsetPathModifier.ts
@@ -22,9 +22,9 @@ import { ShapeModifier } from '@/utils/shapes/modifiers/ShapeModifier'
 interface Segment { points: Vector2[] }
 
 const crossProduct = (a: number[], b: number[]) => [
-    a[1] ?? 0 * (b[2] ?? 0) - (a[2] ?? 0) * (b[1] ?? 0),
-    a[2] ?? 0 * (b[0] ?? 0) - (a[0] ?? 0) * (b[2] ?? 0),
-    a[0] ?? 0 * (b[1] ?? 0) - (a[1] ?? 0) * (b[0] ?? 0),
+    (a[1] ?? 0) * (b[2] ?? 0) - (a[2] ?? 0) * (b[1] ?? 0),
+    (a[2] ?? 0) * (b[0] ?? 0) - (a[0] ?? 0) * (b[2] ?? 0),
+    (a[0] ?? 0) * (b[1] ?? 0) - (a[1] ?? 0) * (b[0] ?? 0),
   ],
 
   polarOffset = (
@@ -72,7 +72,7 @@ const crossProduct = (a: number[], b: number[]) => [
       return null
     }
 
-    return [r[0] ?? 0 / (r[2] ?? 0), r[1] ?? 0 / (r[2] ?? 0)]
+    return [(r[0] ?? 0) / (r[2] ?? 0), (r[1] ?? 0) / (r[2] ?? 0)]
   },
 
   pointDistance = (p1: Vector2, p2: Vector2) =>
@@ -231,7 +231,7 @@ const crossProduct = (a: number[], b: number[]) => [
 
     split = segment.split(flex[0] ?? 0)
     left = split[0] as PolynomialBezier
-    const t = (flex[1] ?? 0 - (flex[0] ?? 0)) / (1 - (flex[0] ?? 0))
+    const t = ((flex[1] ?? 0) - (flex[0] ?? 0)) / (1 - (flex[0] ?? 0))
 
     split = split[1]?.split(t) as PolynomialBezier[]
     const mid = split[0] as PolynomialBezier

--- a/src/utils/shapes/modifiers/PuckerAndBloatModifier.ts
+++ b/src/utils/shapes/modifiers/PuckerAndBloatModifier.ts
@@ -39,12 +39,12 @@ export class PuckerAndBloatModifier extends ShapeModifier {
     let vX, vY, oX, oY, iX, iY
 
     for (i = 0; i < pathLength; i++) {
-      vX = path.v[i]?.[0] ?? 0 + (centerPoint[0] ?? 0 - (path.v[i]?.[0] ?? 0)) * percent
-      vY = path.v[i]?.[1] ?? 0 + (centerPoint[1] ?? 0 - (path.v[i]?.[1] ?? 0)) * percent
-      oX = path.o[i]?.[0] ?? 0 + (centerPoint[0] ?? 0 - (path.o[i]?.[0] ?? 0)) * -percent
-      oY = path.o[i]?.[1] ?? 0 + (centerPoint[1] ?? 0 - (path.o[i]?.[1] ?? 0)) * -percent
-      iX = path.i[i]?.[0] ?? 0 + (centerPoint[0] ?? 0 - (path.i[i]?.[0] ?? 0)) * -percent
-      iY = path.i[i]?.[1] ?? 0 + (centerPoint[1] ?? 0 - (path.i[i]?.[1] ?? 0)) * -percent
+      vX = (path.v[i]?.[0] ?? 0) + ((centerPoint[0] ?? 0) - (path.v[i]?.[0] ?? 0)) * percent
+      vY = (path.v[i]?.[1] ?? 0) + ((centerPoint[1] ?? 0) - (path.v[i]?.[1] ?? 0)) * percent
+      oX = (path.o[i]?.[0] ?? 0) + ((centerPoint[0] ?? 0) - (path.o[i]?.[0] ?? 0)) * -percent
+      oY = (path.o[i]?.[1] ?? 0) + ((centerPoint[1] ?? 0) - (path.o[i]?.[1] ?? 0)) * -percent
+      iX = (path.i[i]?.[0] ?? 0) + ((centerPoint[0] ?? 0) - (path.i[i]?.[0] ?? 0)) * -percent
+      iY = (path.i[i]?.[1] ?? 0) + ((centerPoint[1] ?? 0) - (path.i[i]?.[1] ?? 0)) * -percent
       clonedPath.setTripleAt(
         vX, vY, oX, oY, iX, iY, i
       )

--- a/src/utils/shapes/modifiers/TrimModifier.ts
+++ b/src/utils/shapes/modifiers/TrimModifier.ts
@@ -281,17 +281,17 @@ export class TrimModifier extends ShapeModifier {
         let shapeS
         let shapeE
 
-        if (segments[i]?.s ?? 0 * totalModifierLength <= addedLength) {
+        if ((segments[i]?.s ?? 0) * totalModifierLength <= addedLength) {
           shapeS = 0
         } else {
           shapeS =
-            (segments[i]?.s ?? 0 * totalModifierLength - addedLength) / shapeLength
+            ((segments[i]?.s ?? 0) * totalModifierLength - addedLength) / shapeLength
         }
-        if (segments[i]?.e ?? 0 * totalModifierLength >= addedLength + shapeLength) {
+        if ((segments[i]?.e ?? 0) * totalModifierLength >= addedLength + shapeLength) {
           shapeE = 1
         } else {
           shapeE =
-            (segments[i]?.e ?? 0 * totalModifierLength - addedLength) / shapeLength
+            ((segments[i]?.e ?? 0) * totalModifierLength - addedLength) / shapeLength
         }
         shapeSegments.push([shapeS, shapeE])
       }


### PR DESCRIPTION
While using one of the animations with this player, I've noticed that some elements were animated incorrectly. After a bit of debugging, issues was pin-pointed at following line:

https://github.com/aarsteinmedia/lottie-web/blob/cd947deca4600e9d70508042f17554fbb71c4369/src/utils/properties/KeyframedMultidimensionalProperty.ts#L39

These 2 statements in particular:

- `s[0] ?? 0 + (to[0] ?? 0)`
- `s[1] ?? 0 + (to[1] ?? 0)`

In both of them, `0 + (to[0] ?? 0)` is treated as expression after the `??` operator, instead of adding `to[0] ?? 0` to the result of `s[0] ?? 0`. If `s[0]` is not null/undefined in this case, everything after the `??` operator will just be ignored.

So to prevent this bug from happening, all cases like that should be properly covered in brackets:

```ts
(s[0] ?? 0) + (to[0] ?? 0)
```

<details>
<summary>The same point demonstrated with Node:</summary>
<img width="401" height="321" alt="image" src="https://github.com/user-attachments/assets/df1fd0e8-6728-490b-9afc-cc5808b54a80" />
</details>

I've looked for other cases like that across the repo and covered everything I could find in brackets. You might find other cases like that in the original commit(s) where these `??` operators were added, like this one: 0d22c36be73dbf47278e82e3a55444da78ca22f8. But… it's a huge commit with a lot of changes made at once, so it will be hard to find.

<details>
<summary>Regexes I've used to find other cases (with some false-positives):</summary>

- `\?\? 0 \+`
- `\?\?\s*\d+\s*[-*\/+]`

</details>